### PR TITLE
fix: traefik annotations incorrectly on ingress instead of service

### DIFF
--- a/charts/homepage/CHANGELOG.md
+++ b/charts/homepage/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.2
+- fix: traefik annotations incorrectly on ingress instead of service
+
+## 0.0.1
+- Initial commit

--- a/charts/homepage/Chart.yaml
+++ b/charts/homepage/Chart.yaml
@@ -13,5 +13,5 @@ keywords:
   - gethomepage
   - homepage helm chart
   - homepage helm chart for kubernetes
-version: 0.0.1
+version: 0.0.2
 appVersion: 'v1.2.0'

--- a/charts/homepage/templates/ingress.yaml
+++ b/charts/homepage/templates/ingress.yaml
@@ -5,17 +5,9 @@ metadata:
   name: {{ include "homepage.fullname" . }}
   labels:
     {{- include "homepage.labels" . | nindent 4 }}
-  {{- if or (and (eq .Values.ingress.className "traefik") (gt (int .Values.replicaCount) 1)) (.Values.ingress.annotations) }}
-  annotations:
   {{- with .Values.ingress.annotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- if and (eq .Values.ingress.className "traefik") (gt (int .Values.replicaCount) 1) }}
-    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
-    traefik.ingress.kubernetes.io/service.sticky.cookie.httponly: "true"
-    traefik.ingress.kubernetes.io/service.sticky.cookie.secure: "true"
-    traefik.ingress.kubernetes.io/service.sticky.cookie.samesite: "none"
-  {{- end }}
   {{- end }}
 spec:
   {{- with .Values.ingress.className }}

--- a/charts/homepage/templates/service.yaml
+++ b/charts/homepage/templates/service.yaml
@@ -6,7 +6,17 @@ metadata:
   labels:
     {{- include "homepage.labels" . | nindent 4 }}
   annotations:
+  {{- if and (eq .Values.ingress.className "traefik") (gt (int .Values.replicaCount) 1) }}
+    traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.httponly: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.secure: "true"
+    traefik.ingress.kubernetes.io/service.sticky.cookie.samesite: "none"
+    {{- if .Values.service.annotations }}
+      {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- else }}
     {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service